### PR TITLE
Ensure resize listener registers once and initializes dimensions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,10 @@ import PageMobile from "./pages/mobile";
 import './styles/app.css';
 
 function getWindowDimentions() {
+  if (typeof window === 'undefined') {
+    return { width: 0, height: 0 };
+  }
+
   const { innerWidth: width, innerHeight: height } = window;
   return ({
       width,
@@ -12,16 +16,17 @@ function getWindowDimentions() {
 }
 
 function App() {
-  const [windowDimensions, setWindowD] = useState(getWindowDimentions());
+  const [windowDimensions, setWindowD] = useState(() => getWindowDimentions());
 
   useEffect(() => {
       function handleResize() {
           setWindowD(getWindowDimentions());
       }
 
+      handleResize();
       window.addEventListener('resize', handleResize);
       return () => window.removeEventListener('resize', handleResize);
-  })
+  }, [])
 
   return (
     <div className="App" id="App">


### PR DESCRIPTION
## Summary
- guard window dimension reading for non-browser environments
- register the resize listener only on mount while also refreshing dimensions immediately

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f0021391083268361b7e4a4d4ed19)