### PR TITLE
Add shared ProfileIntro component

### DIFF
--- a/src/components/profileIntro.js
+++ b/src/components/profileIntro.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function ProfileIntro() {
+    return (
+        <>
+            <p className='title'>Freelance Developer</p>
+            <p>Hello, I'm Raphaël</p>
+            <p>I'm a Full Stack Developer from Paris.</p>
+            <p>I work primarily with <code>Javascript</code> and I specialize in the <code>MERN</code> stack.</p>
+            <p>I also enjoy design, and Adobe XD holds no secrets for me.</p>
+            <p>I am currently a freelance developer.</p>
+            <p>Formerly a developer at <code>Opasenior</code></p>
+        </>
+    );
+}

--- a/src/pages/desktop.js
+++ b/src/pages/desktop.js
@@ -5,6 +5,7 @@ import Projectlist from '../components/desktop/list';
 import Logo from '../components/logo';
 import Three from '../components/desktop/three';
 import HoverProvider from '../components/context/hoverlist';
+import ProfileIntro from '../components/profileIntro';
 
 //TODO Changer la flèche de My Works
 
@@ -21,14 +22,8 @@ export default function PageDesktop() {
                             <Logo />
                         </div>
 
-                        <p className='title'>Freelance Developer</p>
-                        <p>Hello, I'm Raphaël</p>
-                        <p>I'm a Full Stack Developer from Paris.</p>
-                        <p>I work primarily with <code>Javascript</code> and I specialize in the <code>MERN</code> stack.</p>
-                        <p>I also enjoy design, and Adobe XD holds no secrets for me.</p>
-                        <p>I am currently a freelance developer.</p>
-                        <p>Formerly a developer at <code>Opasenior</code></p>
-                            
+                        <ProfileIntro />
+
                     </div>
                 </div>
 

--- a/src/pages/mobile.js
+++ b/src/pages/mobile.js
@@ -3,6 +3,7 @@ import Logo from '../components/logo';
 import Linkbar from '../components/modile/linkbar';
 import List from '../components/modile/list';
 import '../styles/mobile.css';
+import ProfileIntro from '../components/profileIntro';
 
 export default function PageMobile(props) {
     return(
@@ -18,13 +19,7 @@ export default function PageMobile(props) {
                 </div>
 
                 <div className='description'>
-                    <p className='title'>Freelance Developer</p>
-                    <p>Hello, I'm Raphaël</p>
-                    <p>I'm a Full Stack Developer from Paris.</p>
-                    <p>I work primarily with <code>Javascript</code> and I specialize in the <code>MERN</code> stack.</p>
-                    <p>I also enjoy design, and Adobe XD holds no secrets for me.</p>
-                    <p>I am currently a freelance developer.</p>
-                    <p>Formerly a developer at <code>Opasenior</code></p>
+                    <ProfileIntro />
                 </div>
 
             </div>


### PR DESCRIPTION
## Summary
- create a reusable ProfileIntro component that contains the shared introduction content
- update both desktop and mobile pages to render the common component instead of duplicate markup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f95d298fc83268f153aaf8db3f62e)