### PR TITLE
Add hook for window dimension handling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,36 +1,14 @@
-import { useEffect, useState } from 'react';
+import './styles/app.css';
+import useWindowDimensions from './hooks/useWindowDimensions';
 import PageDesktop from "./pages/desktop";
 import PageMobile from "./pages/mobile";
-import './styles/app.css';
-
-function getWindowDimentions() {
-  if (typeof window === 'undefined') {
-    return { width: 0, height: 0 };
-  }
-
-  const { innerWidth: width, innerHeight: height } = window;
-  return ({
-      width,
-      height
-  })
-}
 
 function App() {
-  const [windowDimensions, setWindowD] = useState(() => getWindowDimentions());
-
-  useEffect(() => {
-      function handleResize() {
-          setWindowD(getWindowDimentions());
-      }
-
-      handleResize();
-      window.addEventListener('resize', handleResize);
-      return () => window.removeEventListener('resize', handleResize);
-  }, [])
+  const windowDimensions = useWindowDimensions();
 
   return (
     <div className="App" id="App">
-      {windowDimensions.width > 768 ? 
+      {windowDimensions.width > 768 ?
           <div className="Desktop">
             <PageDesktop />
           </div>

--- a/src/hooks/useWindowDimensions.js
+++ b/src/hooks/useWindowDimensions.js
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+function getWindowDimensions() {
+  if (typeof window === 'undefined') {
+    return { width: 0, height: 0 };
+  }
+
+  const { innerWidth: width, innerHeight: height } = window;
+  return { width, height };
+}
+
+export default function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(() => getWindowDimensions());
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return windowDimensions;
+}


### PR DESCRIPTION
## Summary
- extract window dimension handling into a dedicated `useWindowDimensions` hook
- ensure the resize listener is only registered on mount/unmount while capturing initial dimensions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f969d6eb483269f4fa14d2ae12d45)