### PR TITLE
Add unit tests for project list and modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "three": "^0.144.0",
     "web-vitals": "^2.1.4"
   },
-    "scripts": {
-      "start": "react-scripts start",
-      "build": "react-scripts build",
-      "test": "react-scripts test",
-      "test:coverage": "react-scripts test --watchAll=false --coverage",
-      "eject": "react-scripts eject"
-    },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "test:coverage": "react-scripts test --watchAll=false --coverage",
+    "eject": "react-scripts eject"
+  },
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
     "three": "^0.144.0",
     "web-vitals": "^2.1.4"
   },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
+    "scripts": {
+      "start": "react-scripts start",
+      "build": "react-scripts build",
+      "test": "react-scripts test",
+      "test:coverage": "react-scripts test --watchAll=false --coverage",
+      "eject": "react-scripts eject"
+    },
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/src/components/desktop/list.test.js
+++ b/src/components/desktop/list.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Projectlist from './list';
+import { HoverContext } from '../context/hoverlist';
+
+const projects = require('../../projects.json');
+
+describe('Projectlist', () => {
+    test('affiche tous les projets et gère le survol', () => {
+        const handleHover = jest.fn();
+
+        const { container } = render(
+            <HoverContext.Provider value={{ handleHover }}>
+                <Projectlist />
+            </HoverContext.Provider>
+        );
+
+        const projectElements = container.querySelectorAll('.p-element');
+        expect(projectElements).toHaveLength(projects.list.length);
+
+        fireEvent.mouseEnter(projectElements[0]);
+        expect(handleHover).toHaveBeenCalledWith(projects.list[0].name);
+
+        fireEvent.mouseLeave(projectElements[0]);
+        expect(handleHover).toHaveBeenCalledWith(null);
+    });
+});

--- a/src/components/mobile/modal.test.js
+++ b/src/components/mobile/modal.test.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+jest.mock('react-modal', () => {
+    const React = require('react');
+
+    const Modal = ({ isOpen, children, onAfterOpen, onRequestClose }) => {
+        React.useEffect(() => {
+            if (isOpen && onAfterOpen) {
+                onAfterOpen();
+            }
+        }, [isOpen, onAfterOpen]);
+
+        if (!isOpen) {
+            return null;
+        }
+
+        return (
+            <div data-testid="mock-modal" tabIndex={-1} onKeyDown={onRequestClose}>
+                {children}
+            </div>
+        );
+    };
+
+    Modal.setAppElement = () => {};
+
+    return Modal;
+});
+
+import Projectmodal from './modal';
+
+const project = {
+    name: 'Projet test',
+    description: 'Une description brève',
+    stack: ['React', 'Testing Library'],
+    url: 'https://example.com',
+    src: 'https://example.com/src'
+};
+
+describe('Projectmodal', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="root"></div>';
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    test('ouvre et ferme le modal via le bouton et la touche Échap', async () => {
+        render(<Projectmodal project={project} positionX={0} />);
+
+        fireEvent.click(screen.getByText(/more info/i));
+        const modalContent = await screen.findByTestId('mock-modal');
+        expect(modalContent).toHaveTextContent(project.name);
+
+        fireEvent.keyDown(modalContent, { key: 'Escape', code: 'Escape', keyCode: 27 });
+
+        act(() => {
+            jest.runAllTimers();
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByText(project.name)).not.toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add unit tests for the desktop project list hover behavior
- add modal open/close coverage with a lightweight react-modal mock
- add an npm script to run the test suite with coverage

## Testing
- CI=true npm test -- --watchAll=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f982c31588326a770d4b39708745e)